### PR TITLE
Tab component active class -- Use CSS (scss) to control which tab is shown / hidden

### DIFF
--- a/projects/ng-wizi-bulma/src/lib/tabs/tab.component.scss
+++ b/projects/ng-wizi-bulma/src/lib/tabs/tab.component.scss
@@ -1,0 +1,8 @@
+:host(.tab) {
+  visibility: hidden;
+  height: 0;
+  &.is-active {
+    visibility: visible;
+    height: 100%;
+  }
+}

--- a/projects/ng-wizi-bulma/src/lib/tabs/tab.component.ts
+++ b/projects/ng-wizi-bulma/src/lib/tabs/tab.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, HostBinding } from '@angular/core';
 
 @Component({
   selector: 'nwb-tab',
+  styleUrls: ['./tab.component.scss'],
   template: `
     <ng-content>
     </ng-content>

--- a/projects/ng-wizi-bulma/src/lib/tabs/tab.component.ts
+++ b/projects/ng-wizi-bulma/src/lib/tabs/tab.component.ts
@@ -1,9 +1,9 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, HostBinding } from '@angular/core';
 
 @Component({
   selector: 'nwb-tab',
   template: `
-    <ng-content *ngIf="isSelected">
+    <ng-content>
     </ng-content>
   `
 })
@@ -13,6 +13,9 @@ export class NwbTabComponent {
   @Input()
   icon: string;
   index: number;
+  
+  @HostBinding('class.is-active') get isActive() { return this.isSelected; }
+  @HostBinding('class.tab') true;
 
   isSelected: boolean;
 


### PR DESCRIPTION
I recently used the tab component to render different `canvas` chart elements.  The `canvas` elements do not render initially using `*ngIf`.  The graphs would only render on window resize events, which wouldn't be intuitive to the user and would be frustrating to do each time.  I also had one chart that was rendering a great deal of data and would re-render each time the tab was clicked using the `*ngIf`.  I found that using `visibility: hidden` and `visibility: visible` increased the usability after the initial render of the graph since the element was still in the DOM.

I added the necessary CSS and `HostBinding` to control which tab is shown on the page.  I thought that maybe this way of doing it would allow for more flexibility for anyone who runs into my same issue.