### PR TITLE
Display dialog's footer even if there's only one of the buttons present

### DIFF
--- a/projects/ng-wizi-bulma/src/lib/dialog/dialog.component.html
+++ b/projects/ng-wizi-bulma/src/lib/dialog/dialog.component.html
@@ -23,7 +23,7 @@
     </section>
 
     <footer class="modal-card-foot"
-            *ngIf="!config.loading && config.cancelButtonText.length > 0 && config.okButtonText.length > 0" #footer>
+            *ngIf="!config.loading && (config.cancelButtonText.length > 0 || config.okButtonText.length > 0)" #footer>
       <button class="button column is-medium is-danger is-4" *ngIf="config.cancelButtonText"
               (click)="cancelHandler()" #cancelButton>{{config.cancelButtonText}}
       </button>


### PR DESCRIPTION
If there's only one button not present, it won't display the footer at all. In my case, I didn't want to have a cancel button, which currently is not possible. 